### PR TITLE
Tool updates

### DIFF
--- a/tools/convert/cli.js
+++ b/tools/convert/cli.js
@@ -16,9 +16,11 @@ const argOptions = [
   { name: 'pretty-print', alias: 'p', type: Boolean, description: 'Generate human-readable output file.'},
 ]
 
+const commandLineHeader = 'ZzFXM Song Convertion Tool';
+
 const usage = commandLineUsage([
   {
-    header: 'ZzFXM Song Convertion Tool',
+    header: commandLineHeader,
     content: 'Generates ZzFXM song data from other formats.'
   },
   {
@@ -31,6 +33,29 @@ const usage = commandLineUsage([
 const process = async () => {
   let buffer = await readFile(options.src);
   let song = convertSong(buffer, options);
+  const assignedInstruments = []
+  const unassignedInstruments = []
+
+  let instrumentCount = song.getInstrumentCount();
+
+   for (let i=0; i<instrumentCount;i++) {
+    if (song.getInstrument(i)[0] === 0) {
+      unassignedInstruments.push(song.getInstrumentName(i))
+    } else {
+      assignedInstruments.push(song.getInstrumentName(i))
+    }
+  }
+
+  console.log(`- Converted "${song.title}"`);
+  console.log(`  • Sequence length: ${song.getSequenceLength()}`);
+  console.log(`  • Instruments: ${song.getInstrumentCount()}`);
+  console.log(`  • Patterns: ${song.getPatternCount()}`);
+  console.log(`- Created ${assignedInstruments.length} zzfx instruments:`);
+  console.log(`  • ${assignedInstruments.join(', ')}`);
+  console.log(`- Created ${unassignedInstruments.length} empty instruments`);
+  console.log(`  • ${unassignedInstruments.join(', ')}`);
+
+
   let file;
   if (options.out) {
     file = options.out;
@@ -40,7 +65,7 @@ const process = async () => {
     file = 'song.js';
   }
   await writeFile(file, `export default ${song.toString()}`);
-  console.log(`File "${file}" written successfully.`);
+  console.log(`\nFile "${file}" written successfully.`);
 }
 
 
@@ -52,6 +77,7 @@ try {
     if (!options.src) {
       throw new Error('Source file is required');
     }
+    console.log(commandLineUsage([{header: commandLineHeader}]));
     process();
   }
 } catch (e) {

--- a/tools/convert/cli.js
+++ b/tools/convert/cli.js
@@ -39,7 +39,7 @@ const process = async () => {
   let instrumentCount = song.getInstrumentCount();
 
    for (let i=0; i<instrumentCount;i++) {
-    if (song.getInstrument(i)[0] === 0) {
+    if (!song.getInstrument(i).length || !song.getInstrument(i)[0] === 0) {
       unassignedInstruments.push(song.getInstrumentName(i))
     } else {
       assignedInstruments.push(song.getInstrumentName(i))
@@ -50,11 +50,16 @@ const process = async () => {
   console.log(`  • Sequence length: ${song.getSequenceLength()}`);
   console.log(`  • Instruments: ${song.getInstrumentCount()}`);
   console.log(`  • Patterns: ${song.getPatternCount()}`);
-  console.log(`- Created ${assignedInstruments.length} zzfx instruments:`);
-  console.log(`  • ${assignedInstruments.join(', ')}`);
-  console.log(`- Created ${unassignedInstruments.length} empty instruments`);
-  console.log(`  • ${unassignedInstruments.join(', ')}`);
 
+  if (assignedInstruments.length) {
+    console.log(`- Created ${assignedInstruments.length} zzfx instruments:`);
+    console.log(`  • ${assignedInstruments.join(', ')}`);
+  }
+
+  if (unassignedInstruments.length) {
+    console.log(`- Created ${unassignedInstruments.length} empty instruments`);
+    console.log(`  • ${unassignedInstruments.join(', ')}`);
+  }
 
   let file;
   if (options.out) {

--- a/tools/convert/convert.js
+++ b/tools/convert/convert.js
@@ -34,7 +34,7 @@ export const convertSong = (buffer, options) => {
     }
     else if (type === 'sequence') {
       value.forEach((value, index) => {
-        song.setSequence(index, value)
+        song.setSequencePattern(index, value)
       });
     }
     else if (type === 'sampleMeta') {
@@ -61,7 +61,7 @@ export const convertSong = (buffer, options) => {
       // console.log(`Pattern ${currentPattern}`)
       song.setPatternCount(currentPattern + 1)
       song.setPatternChannelCount(currentPattern, 4);
-      song.setPatternLength(currentPattern, patternLength);
+      song.setPatternRowCount(currentPattern, patternLength);
     } else if (type === 'patternEnd') {
       patternLength = 64;
     }
@@ -85,7 +85,7 @@ export const convertSong = (buffer, options) => {
       currentEffectCode = value;
       if (value === EFFECT_CODE_PATTERN_BREAK) {
         patternLength = currentRow
-        song.setPatternLength(currentPattern, patternLength + 1);
+        song.setPatternRowCount(currentPattern, patternLength + 1);
       }
     }
     else if (type === 'noteEffectParam') {

--- a/tools/convert/package.json
+++ b/tools/convert/package.json
@@ -1,15 +1,15 @@
 {
   "name": "zzfxm-convert",
   "version": "1.0.0",
-  "description": "",
+  "description": "Song conversion tool for ZzFXM",
   "type": "module",
   "main": "convert.js",
   "bin": "./bin/zzfx-convert",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "ISC",
+  "author": "Keith Clark",
+  "license": "MIT",
   "dependencies": {
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.0",

--- a/tools/convert/package.json
+++ b/tools/convert/package.json
@@ -15,5 +15,9 @@
     "command-line-usage": "^6.1.0",
     "song-parsers": "file:../local_modules/song-parsers",
     "zzfxm-song-facade": "file:../local_modules/zzfxm-song-facade"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/keithclark/ZzFXM"
   }
 }

--- a/tools/local_modules/song-parsers/protracker/README.md
+++ b/tools/local_modules/song-parsers/protracker/README.md
@@ -7,23 +7,26 @@ Name | Value | Description
 `title` | String | The title of the song.
 `channelCount` | Number | The number of channels.
 `sequence` | Number[] | The pattern index sequence for the song.
-`sampleMeta` | Sample | A song sample meta data.
+`sampleMeta` | SampleMeta | A song sample meta data.
 `sampleData` | Array | A song sample data (8-bit unsigned mono).
 `pattern` | Number | Emitted when the parser enters a new pattern. Token value indicates the pattern number.
 `patternEnd` | Number | Emitted when the parser leaves a pattern. Token value indicates the pattern number.
 `row` | Number | Emitted when the parser enters a new pattern row. Token value indicates the row number.
 `rowEnd` | Number | Emitted when the parser leaves a row. Token value indicates the row number.
-`channel` | Number | Emitted when the parser enters a new row channel. Token value indicates the row number.
+`channel` | Number | Emitted when the parser enters a new row channel. Token value indicates the channel number.
 `channelEnd` | Number | Emitted when the parser leaves a channel. Token value indicates the channel number.
 `notePeriod` | Number | The period to play or `0` if the row is blank.
 `noteInstrument` | Number | The instrument to play or `0` if the row is blank.
 `noteEffectCode` | Number | The effect to use or `0` if no effect is set.
 `noteEffectParam` | Number | The effect parameter to apply or `0` if no param is set.
 
-### Sample Token
+### SampleMeta Token
 
 Name | Value | Description
 -|-|-
 `name` | String | Name of the sample
 `size` | Number | Length of the sample in bytes
-`data` | Int8Array | Sample data.
+`finetune` | Number | Fine tuning value of the sample
+`volume` | Number | Volume adjust for the sample
+`loopStart` | Number | Loop start position for the sample
+`loopEnd` | Number | Loop end position for the sample

--- a/tools/local_modules/zzfxm-song-compressor/README.md
+++ b/tools/local_modules/zzfxm-song-compressor/README.md
@@ -1,0 +1,36 @@
+# ZzFXM Song Compression Module
+
+Use this module for packing ZzFXM song data in applications.
+
+```js
+import { packSong } from 'zzfxm-song-compressor';
+import mySong from 'path/to/song.js';
+
+console.log(packSong(mySong, {options}));
+```
+
+## Plugins
+
+You can extend the compressor by writing plugins. A plugin is a JavaScript module that executes code on a `ZzfxmSongFacade` instance. Plugins mutate the song data through the facade.
+
+A basic plugin has an `execute` method and a human-friendly `name` property, which can be used in reports. Plugins can also return a `postProcess` method, which will be called after the song has been processed by every plugin. `postProcess` is called with a stringified version of the compressed song.
+
+```js
+/**
+ * An example plugin for removing song meta data
+ */
+
+const execute = (facade) => {
+  facade.clearMeta()
+}
+
+// Add a comment to the generated output
+const postProcess = (songString) => `/* Hai! */\n${songString}`;
+
+// export the plugin
+export default {
+  name: "Remove all song metadata",
+  execute,
+  postProcess
+};
+```

--- a/tools/local_modules/zzfxm-song-compressor/pack.js
+++ b/tools/local_modules/zzfxm-song-compressor/pack.js
@@ -1,0 +1,53 @@
+import removeConcurrentInstruments from './plugins/removeConcurrentInstruments.js';
+import trimEmptyChannels from './plugins/trimEmptyChannels.js';
+import removeMetadata from './plugins/removeMetadata.js';
+import encodePatternData from './plugins/encodePatternData.js';
+import removeSilentInstruments from './plugins/removeSilentInstruments.js';
+
+
+const getPluginList = options => {
+  const plugins = [];
+  if (options.removeSilentInstruments) {
+    plugins.push(removeSilentInstruments);
+  }
+  if (options.removeConcurrentInstruments) {
+    plugins.push(removeConcurrentInstruments);
+  }
+  if (options.trimEmptyChannels) {
+    plugins.push(trimEmptyChannels);
+  }
+  if (options.removeMetadata) {
+    plugins.push(removeMetadata);
+  }
+  if (options.encodePatternData) {
+    plugins.push(encodePatternData);
+  }
+  return plugins;
+}
+
+
+export const packSong = (song, options, callback) => {
+
+  const plugins = getPluginList(options);
+
+  plugins.forEach(plugin => {
+    const input = song.toString();
+    plugin.execute(song);
+    let output = song.toString();
+    if (callback) {
+      callback({
+        name: plugin.name,
+        input,
+        output
+      });
+    }
+  });
+
+  song = song.toString();
+
+  plugins.filter(plugin => !!plugin.postProcess).forEach(plugin => {
+    song = plugin.postProcess(song);
+  });
+
+  return song;
+}

--- a/tools/local_modules/zzfxm-song-compressor/package.json
+++ b/tools/local_modules/zzfxm-song-compressor/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "zzfxm-song-compressor",
+  "type": "module",
+  "version": "1.0.0",
+  "description": "Compression tools for ZzFXM songs",
+  "main": "pack.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Keith Clark",
+  "license": "MIT"
+}

--- a/tools/local_modules/zzfxm-song-compressor/plugins/encodePatternData.js
+++ b/tools/local_modules/zzfxm-song-compressor/plugins/encodePatternData.js
@@ -1,0 +1,30 @@
+/**
+ * This plugin encodes the song pattern data into string data.
+ */
+
+/**
+ * Encode pattern data into string
+ * @param {ZzfxmSongFacade} facade
+ */
+const execute = facade => {
+  // TODO: Figure a better way of doing this - accessing _data is a hack.
+  facade._data[1] = facade._data[1].map(pattern => {
+    return pattern.map(channel => {
+      // for RLE:
+      // return channel.flat().map(x=>String.fromCharCode(x | 64)).join('').replace(/(.)(\1{1,62})/g, (m,c,r) => c + String.fromCharCode(61) + String.fromCharCode(r.length|64));
+      return [...channel].flat().map(x=>String.fromCharCode(x | 64)).join('');
+    });
+  });
+}
+
+const postProcess = songString => {
+  return songString.replace(/(\[\[".*"\]\])/, '$1.map(v=>v.map(v=>[...v].map(x=>x.charCodeAt()&63)))');
+  // for RLE:
+  // song = song.replace(/(\[\[".*"\]\])/, '$1.map(v=>v.map(v=>[...(v.replace(/.=./g,x=>x[0].repeat(x.charCodeAt(2)-63)))].map(x=>x.charCodeAt()&63)))');
+}
+
+export default {
+  name: "Encode pattern data",
+  execute,
+  postProcess
+};

--- a/tools/local_modules/zzfxm-song-compressor/plugins/removeConcurrentInstruments.js
+++ b/tools/local_modules/zzfxm-song-compressor/plugins/removeConcurrentInstruments.js
@@ -1,0 +1,49 @@
+/**
+ * This plugin removes unnecessary repeating instruments from within a channel.
+ *
+ * Input:
+ *
+ * A-3 1 0
+ * --- 0 0
+ * B-3 1 0
+ * --- 0 0
+ *
+ * Output:
+ *
+ * A-3 1 0
+ * --- 0 0
+ * B-3 0 0
+ * --- 0 0
+ */
+
+/**
+ * Removes instruments with a volume of 0
+ * @param {ZzfxmSongFacade} facade
+ */
+const execute = facade => {
+  const patternCount = facade.getPatternCount();
+
+  for (let patternIndex = 0; patternIndex < patternCount; patternIndex++) {
+    const patternLength = facade.getPatternRowCount(patternIndex);
+    const channelCount = facade.getPatternChannelCount(patternIndex)
+
+    for (let channelIndex = 0; channelIndex < channelCount; channelIndex++) {
+      let lastInstrument;
+      for (let rowIndex = 0; rowIndex < patternLength; rowIndex++) {
+        const instrument = facade.getNoteInstrument(patternIndex, channelIndex, rowIndex);
+        if (instrument) {
+          if (instrument === lastInstrument) {
+            facade.setNoteInstrument(patternIndex, channelIndex, rowIndex, null);
+          } else {
+            lastInstrument = instrument
+          }
+        }
+      }
+    }
+  }
+}
+
+export default {
+  name: "Remove concurrent instrument definitions",
+  execute
+};

--- a/tools/local_modules/zzfxm-song-compressor/plugins/removeMetadata.js
+++ b/tools/local_modules/zzfxm-song-compressor/plugins/removeMetadata.js
@@ -1,0 +1,17 @@
+/**
+ * This plugin removes the human-readable meta data from songs
+ */
+
+/**
+ * Removes song metadata
+ * @param {ZzfxmSongFacade} facade
+ */
+
+const execute = facade => {
+  facade.clearMeta()
+}
+
+export default {
+  name: "Remove all song metadata",
+  execute
+};

--- a/tools/local_modules/zzfxm-song-compressor/plugins/removeSilentInstruments.js
+++ b/tools/local_modules/zzfxm-song-compressor/plugins/removeSilentInstruments.js
@@ -1,0 +1,22 @@
+/**
+ * This plugin removes instruments with zero volume. These can be added by the
+ * song conversion tool or be edited out. Notes using the instruments are also
+ * removed.
+ */
+
+/**
+ * Removes instruments with a volume of 0
+ * @param {ZzfxmSongFacade} facade
+ */
+const execute = facade => {
+  for (let instrumentIndex = facade.getInstrumentCount()-1; instrumentIndex >=0; instrumentIndex--) {
+    if (facade.getInstrument(instrumentIndex)[0] === 0) {
+      facade.deleteInstrument(instrumentIndex)
+    }
+  }
+}
+
+export default {
+  name: "Remove instruments with zero-volume",
+  execute
+};

--- a/tools/local_modules/zzfxm-song-compressor/plugins/trimEmptyChannels.js
+++ b/tools/local_modules/zzfxm-song-compressor/plugins/trimEmptyChannels.js
@@ -1,0 +1,53 @@
+/**
+ * This plugin removes empty channels from the right side of a song pattern.
+ * Empty channels between populated channels are kept to preserve stereo panning
+ * and sustained notes.
+ *
+ * Input:
+ *
+ * A-3 1 0  |  --- 0 0  |  C-3 1 0  |  --- 0 0
+ * --- 0 0  |  --- 0 0  |  --- 0 0  |  --- 0 0
+ * B-3 1 0  |  --- 0 0  |  A-3 1 0  |  --- 0 0
+ * --- 0 0  |  --- 0 0  |  --- 0 0  |  --- 0 0
+ *
+ * Output:
+ *
+ * A-3 1 0  |  --- 0 0  |  C-3 1 0
+ * --- 0 0  |  --- 0 0  |  --- 0 0
+ * B-3 1 0  |  --- 0 0  |  A-3 1 0
+ * --- 0 0  |  --- 0 0  |  --- 0 0
+ */
+
+/**
+ * Removes empty channels from the end of patterns.
+ * @param {ZzfxmSongFacade} facade
+ */
+const execute = facade => {
+  const patternCount = facade.getPatternCount();
+
+  for (let patternIndex = 0; patternIndex < patternCount; patternIndex++) {
+    const patternLength = facade.getPatternRowCount(patternIndex);
+    const channelCount = facade.getPatternChannelCount(patternIndex);
+    let empty = true;
+    for (let channelIndex = channelCount-1; channelIndex >= 0; channelIndex--) {
+      for (let rowIndex = 0; rowIndex < patternLength; rowIndex++) {
+        const note = facade.getNote(patternIndex, channelIndex, rowIndex);
+        const [instrument, period, attenuation] = note;
+        if (instrument || period || attenuation) {
+          empty = false;
+          break;
+        }
+      }
+      if (empty) {
+        facade.setPatternChannelCount(patternIndex, channelIndex)
+      } else {
+        break;
+      }
+    }
+  }
+}
+
+export default {
+  name: "Trim empty trailing channels from patterns",
+  execute
+};

--- a/tools/local_modules/zzfxm-song-facade/ZzfxmSongFacade.js
+++ b/tools/local_modules/zzfxm-song-facade/ZzfxmSongFacade.js
@@ -371,6 +371,18 @@ export class ZzfxmSongFacade {
   }
 
   /**
+   * Gets the attenuation for a specific row of a channel in a pattern.
+   *
+   * @param {Number} pattern The index of the pattern containing the note
+   * @param {Number} channel The index of the chanel containing the note
+   * @param {Number} row The index of the row containing the note
+   * @returns {Number} The new attenuation for the note
+   */
+  getNoteAttenuation(pattern, channel, row) {
+    return this._data[PATTERN_INDEX][pattern][channel][row * 3 + 2];
+  }
+
+  /**
    * Returns all the notes for a specific position in the song.
    *
    * @param {Number} position The position to retrieve notes for

--- a/tools/local_modules/zzfxm-song-facade/encoding.js
+++ b/tools/local_modules/zzfxm-song-facade/encoding.js
@@ -16,9 +16,13 @@ export const encodeInstruments = instruments => {
       x = instrument.map((v,i) => {
         let encoded = encodeNumber(v);
 
-        // zzfx defaults volume to `1` so we strip if
+        // zzfx defaults volume to `1` so we can drop it if defined.
         if (i == 0 && encoded == '1') {
-          encoded = ''
+          encoded = '';
+        }
+        // zzfx defaults volume to `1` so we need to restore the `0`
+        else if (i == 0 && encoded == '') {
+          encoded = '0';
         }
         // zzfx defaults `randomness` to `.05` - we need to restore the `0`
         else if (i == 1 && encoded == '') {
@@ -35,6 +39,9 @@ export const encodeInstruments = instruments => {
         // zzfx defaults `sustainVolume` to `1` - we need to restore the `0`
         else if (i == 17 && encoded == '') {
           encoded = '0';
+        }
+        else if (encoded === '0' || encoded === 'null') {
+          encoded = ''
         }
         return encoded;
       });
@@ -83,11 +90,57 @@ export const encodeMetadata = metaData => {
 
 
 /**
+ * Encodes song panning data into a string.
+ *
+ * @param {Object} panning The song panning data
+ */
+export const encodePanning = panning => {
+  return JSON.stringify(panning);
+}
+
+
+/**
+ * Encodes song speed value into a string.
+ *
+ * @param {Object} panning The song panning data
+ */
+export const encodeSpeed = speed => {
+  if (speed !== 4) {
+    return JSON.stringify(speed);
+  }
+}
+
+/**
  * Encodes song data into a string, removing values as needed to keep size to a
  * minimum.
  *
  * @param {*} song The song to encode
  */
 export const encodeSong = song => {
-  return `[${encodeInstruments(song[0])},${encodePatterns(song[1])},${encodeSequence(song[2])},${song[3]},${encodeMetadata(song[4])}]`;
+  let elements = [
+    encodeInstruments(song[0]),
+    encodePatterns(song[1]),
+    encodeSequence(song[2]),
+    encodeSpeed(song[3]),
+    encodePanning(song[4]),
+    encodeMetadata(song[5])
+  ];
+  return `[${elements.join(',')}]`
+}
+
+/**
+ * Decodes a string representation of a song into an array
+ *
+ * @param {string} song The song to decode
+ */
+export const decodeSong = song => {
+  let jsonSong = song
+    .replace(/^export\s+default\s+/,'')
+    .replace(/\[,/g,'[null,')
+    .replace(/,(?=[,\]])/g,',null')
+    .replace(/([\[,]-?)(?=\.)/g,'$10');
+
+  return JSON.parse(jsonSong, (key, value) => {
+    return value === null ? undefined : value;
+  });
 }

--- a/tools/songpack/README.md
+++ b/tools/songpack/README.md
@@ -1,0 +1,28 @@
+# ZzFXM Song Compressor
+
+This CLI tool compresses ZzFXM songs.
+
+## Installation
+
+1. Clone this repo
+2. Change to the convert tool directory and install dependencies:
+```
+cd tools/songpack
+npm install
+```
+
+## Use
+
+From the `tools/songpack` dir you can run:
+
+```
+> ./bin/zzfx-songpack my-song.js my-packed-song.js
+```
+
+## Options
+
+Use the `--help` argument for more info.
+
+```
+zzfx-songpack --help
+```

--- a/tools/songpack/bin/zzfxm-songpack
+++ b/tools/songpack/bin/zzfxm-songpack
@@ -1,0 +1,3 @@
+#!/usr/bin/env node --experimental-modules
+
+import '../cli.js';

--- a/tools/songpack/cli.js
+++ b/tools/songpack/cli.js
@@ -1,0 +1,122 @@
+import commandLineUsage from 'command-line-usage';
+import commandLineArgs from 'command-line-args';
+import { packSong } from 'zzfxm-song-compressor';
+import { promises } from 'fs';
+import { ZzfxmSongFacade } from '../local_modules/zzfxm-song-facade/ZzfxmSongFacade.js';
+import { deflate } from 'zlib';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+const chalk = require('chalk');
+
+const {readFile, writeFile} = promises;
+
+const commandLineHeader = 'ZzFXM Song Packing Tool';
+
+const argOptions = [
+  { name: 'files', type: String, multiple: true, defaultOption: true, description: 'The source file to compress and optional output file'},
+  { name: 'help', type: Boolean, description: "Show this help"},
+  { name: 'encode', type: Boolean, description: "Encode the pattern data as strings"},
+  { name: 'keep-slient-instruments', type: Boolean, description: "Don't remove any slient instruments (and notes using them) from the song"},
+  { name: 'keep-concurrent-instruments', type: Boolean, description: "Don't remove unnecessary repeated instrument codes from channel data"},
+  { name: 'keep-metadata', type: Boolean, description: "Don't remove song metadata" },
+  { name: 'keep-empty-channels', type: Boolean, description: "Don't trim empty trailing channels from song patterns'"},
+];
+
+const usage = commandLineUsage([
+  {
+    header: commandLineHeader,
+    content: 'Compresses ZzFXM song data'
+  },
+  {
+    header: 'Synopsis',
+    content: '$ zzfxm-songpack {underline input-path} [{underline output-path}] [options]'
+  },
+  {
+    header: 'Options',
+    hide: ['files'],
+    optionList: argOptions
+  },
+  {
+    header: 'Examples',
+    content: '$ zzfxm-songpack my-song.js my-packed-song.js --encode'
+  },
+]);
+
+const getZippedSize = buffer => new Promise((resolve, reject) => {
+  deflate(buffer, (err, buffer) => {
+    if (err) {
+      reject(err);
+    } else {
+      resolve(buffer.length);
+    }
+  });
+});
+
+const processFile = async (src, dest, options) => {
+  let buffer = await readFile(src);
+  buffer = buffer.toString();
+  buffer = buffer.replace(/\/\*[\w\W]+?\*\//g, '');
+  buffer = buffer.replace(/export\s+default\s+/g, '');
+  buffer = buffer.replace(/;$/m, '');
+  buffer = buffer.trim();
+
+  const song = ZzfxmSongFacade.fromString(buffer);
+
+  console.log(commandLineUsage([{header: commandLineHeader}]));
+
+  const packed = packSong(song, options, pluginResult => {
+    const inputSize = pluginResult.input.length;
+    const outputSize = pluginResult.output.length;
+    const message = `- ${pluginResult.name}: ${inputSize} -> ${outputSize}`;
+    if (outputSize < inputSize) {
+      console.log(chalk.green(message));
+    } else if (outputSize > inputSize) {
+      console.log(chalk.red(message));
+    } else {
+      console.log(message);
+    }
+  });
+  const gzippedBefore = await getZippedSize(buffer);
+  const gzippedAfter = await getZippedSize(packed);
+
+  console.log(`\nOriginal size: ${buffer.length} (${gzippedBefore} gzipped)`);
+  console.log(`Packed size: ${packed.length} (${gzippedAfter} gzipped)`);
+
+  await writeFile(dest, `export default ${packed}`);
+  console.log(`\nFile "${dest}" written successfully.`);
+}
+
+const process = async argOptions => {
+  const options = commandLineArgs(argOptions, { camelCase: true });
+
+  if (options.help) {
+    console.log(usage);
+    return;
+  }
+
+  if (!options.files) {
+    throw new Error('Source file is required.');
+  }
+
+  if (options.files.length > 2) {
+    throw new Error('Too many files specified.');
+  }
+
+  const src = options.files[0];
+  const dest = options.files[1] || 'packed.js';
+
+  await processFile(src, dest, {
+    removeSilentInstruments: !options.keepSlientInstruments,
+    removeConcurrentInstruments: !options.keepConcurrentInstruments,
+    trimEmptyChannels: !options.keepEmptyChannels,
+    removeMetadata: !options.keepMetadata,
+    encodePatternData: !!options.encode
+  });
+}
+
+
+process(argOptions).catch(e => {
+  console.error(`${e.message} - Please use --help for more information.`);
+});

--- a/tools/songpack/package-lock.json
+++ b/tools/songpack/package-lock.json
@@ -1,0 +1,169 @@
+{
+  "name": "zzfxm-song-pack-cli",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "requires": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      }
+    },
+    "command-line-usage": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
+      "integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
+      "requires": {
+        "array-back": "^4.0.0",
+        "chalk": "^2.4.2",
+        "table-layout": "^1.0.0",
+        "typical": "^5.2.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+    },
+    "reduce-flatten": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w=="
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table-layout": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+      "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+      "requires": {
+        "array-back": "^4.0.1",
+        "deep-extend": "~0.6.0",
+        "typical": "^5.2.0",
+        "wordwrapjs": "^4.0.0"
+      },
+      "dependencies": {
+        "array-back": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+          "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+        },
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
+    },
+    "wordwrapjs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+      "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+      "requires": {
+        "reduce-flatten": "^2.0.0",
+        "typical": "^5.0.0"
+      },
+      "dependencies": {
+        "typical": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+          "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg=="
+        }
+      }
+    },
+    "zzfxm-song-compressor": {
+      "version": "file:../local_modules/zzfxm-song-compressor"
+    },
+    "zzfxm-song-facade": {
+      "version": "file:../local_modules/zzfxm-song-facade"
+    }
+  }
+}

--- a/tools/songpack/package.json
+++ b/tools/songpack/package.json
@@ -1,0 +1,22 @@
+{
+  "type": "module",
+  "name": "zzfxm-song-pack-cli",
+  "description": "ZzFXM CLI song compression tool",
+  "version": "1.0.0",
+  "bin": "./bin/zzfx-songpack",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Keith Clark",
+  "license": "MIT",
+  "dependencies": {
+    "command-line-args": "^5.1.1",
+    "command-line-usage": "^6.1.0",
+    "zzfxm-song-compressor": "file:../local_modules/zzfxm-song-compressor",
+    "zzfxm-song-facade": "file:../local_modules/zzfxm-song-facade"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/keithclark/ZzFXM"
+  }
+}


### PR DESCRIPTION
This PR contains various updates to ZzFXM tooling:

* ZzfxmSongFacade has lots of new methods for working with songs
* New Compression Module - Portable code for compressing zzfxm songs
* New song packing CLI tool.
* Conversion tool now semi-emulates the protracker volume slide to make songs using that effect sound a little better
* Conversion tool fixes for channel panning.