### PR TITLE
Use "window" instead of "top" for AudioContext

### DIFF
--- a/zzfx.js
+++ b/zzfx.js
@@ -14,4 +14,4 @@ zzfxV=.3
 zzfxR=44100
 
 // zzfxX - the common audio context
-zzfxX=new(top.AudioContext||webkitAudioContext);
+zzfxX=new(window.AudioContext||webkitAudioContext);


### PR DESCRIPTION
I was testing from Codepen, and getting the following issue:

```
Uncaught DOMException: Blocked a frame with origin "https://cdpn.io" from accessing a cross-origin frame.
```

And this was solved using `window` instead, e.g: https://codepen.io/jdnichollsc/pen/KKMRPrr

Also `ZzFX` use `window` too: https://github.com/KilledByAPixel/ZzFX/blob/master/ZzFX.js#L306

Thanks!
