### PR TITLE
Fix / as shortcut key in Firefox, prevent arrow shortcuts from triggering browser behaviors

### DIFF
--- a/tools/tracker/public/zzfx.js
+++ b/tools/tracker/public/zzfx.js
@@ -14,4 +14,4 @@ zzfxV=.3;
 zzfxR=44100;
 
 // zzfxX - the common audio context
-zzfxX=new(top.AudioContext||webkitAudioContext);
+zzfxX=new(window.AudioContext||webkitAudioContext);

--- a/tools/tracker/src/App.svelte
+++ b/tools/tracker/src/App.svelte
@@ -117,8 +117,10 @@
 
     if (key === 'ArrowLeft') {
       $selectedChannel--;
+      event.preventDefault();
     } else if (key === 'ArrowRight') {
       $selectedChannel++;
+      event.preventDefault();
     } else if (key === 'ArrowUp') {
       if (altKey) {
         const step = shiftKey ? ATTENUATION_COARSE_STEP : ATTENUATION_FINE_STEP;
@@ -127,6 +129,7 @@
         const step = shiftKey ? PATTERN_ROW_COARSE_STEP : PATTERN_ROW_FINE_STEP;
         $selectedRow = Math.max(0, $selectedRow - step);
       }
+      event.preventDefault();
     } else if (key === 'ArrowDown') {
       if (altKey) {
         const step = shiftKey ? ATTENUATION_COARSE_STEP : ATTENUATION_FINE_STEP;
@@ -135,8 +138,10 @@
         const step = shiftKey ? PATTERN_ROW_COARSE_STEP : PATTERN_ROW_FINE_STEP;
         $selectedRow = Math.min($patterns[$selectedPattern][0].length - 3, $selectedRow + step);
       }
+      event.preventDefault();
     } else if (key === ' ') {
       setNote($selectedPattern, $selectedChannel, $selectedRow, -1);
+      event.preventDefault();
     } else if (key === 'Backspace') {
       event.preventDefault();
       setNote($selectedPattern, $selectedChannel, $selectedRow, 0);
@@ -162,6 +167,7 @@
       if (note) {
         setNote($selectedPattern, $selectedChannel, $selectedRow, note);
         playNote($patterns[$selectedPattern][$selectedChannel][0] || 0, note);
+        event.preventDefault();
       }
     }
   }


### PR DESCRIPTION
`/` in firefox is a Find in Page shortcut, which revoked focus from the
page. And at least for me, Arrows + cmd + shift was triggering scroll
behaviors in a Tree Tab extension I run (tabs as a list to the side).
Since that and other behaviors are hard to predict, I think it's best to
always preventDefault() once it's clear that a known shortcut is going
to be triggered.

This should also fix #37 ! This behavior was one of the first I encountered upon playing around with the app 😢 

Thanks for making a cool Tracker app! I plan to use it for some JS13k experiments 😎 